### PR TITLE
allow default nix-index

### DIFF
--- a/,
+++ b/,
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # usage example:
 #   $ , yarn --help

--- a/,
+++ b/,
@@ -6,8 +6,16 @@
 # If there are multiple candidates, the user chooses one using `fzy`.
 set -euo pipefail
 
+DEFAULT_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/nix-index"
+NIX_INDEX_DB="${NIX_INDEX_DB:-$DEFAULT_CACHE}"
+
 if [[ $# -lt 1 ]]; then
   >&2 echo "usage: , <program> [arguments]"
+  exit 1
+fi
+
+if [[ ! -f "${NIX_INDEX_DB}/files" ]]; then
+  >&2 echo "no nix-index cache in '$NIX_INDEX_DB', run nix-index"
   exit 1
 fi
 


### PR DESCRIPTION
Fallback to the default nix-index location if the `NIX_INDEX_DB` isn't provided

Fixed shebang to `#!/usr/bin/env bash`. Most users will install with nix which will patch shebangs but I really don't like `#!/bin/bash` :slightly_smiling_face: 