### PR TITLE
Prefer local nix-index if present

### DIFF
--- a/,
+++ b/,
@@ -18,6 +18,13 @@ else
   install=""
 fi
 
+# if a nix-index exists locally; use that as it's likely much more recent
+# than the prebuilt one.
+database=$PREBUILT_NIX_INDEX_DB
+if [ -f "${HOME}/.cache/nix-index/files" ]; then
+    database="${HOME}/.cache/nix-index"
+fi
+
 argv0=$1; shift
 
 case "${argv0}" in
@@ -25,7 +32,7 @@ case "${argv0}" in
     attr="${argv0}"
     ;;
   *)
-    attr="$(nix-locate --db "${NIX_INDEX_DB}" --top-level --minimal --at-root --whole-name "/bin/${argv0}")"
+    attr="$(nix-locate --db "${database}" --top-level --minimal --at-root --whole-name "/bin/${argv0}")"
     if [[ "$(echo "${attr}" | wc -l)" -ne 1 ]]; then
       attr="$(echo "${attr}" | fzy)"
     fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore nix-build result folter
+result

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# ignore nix-build result folter
+# ignore nix-build result folder
 result


### PR DESCRIPTION
The nix-index database offered in the derivation may be more out of date than what is present on the system.

In fact, prefer any local nix-index database to the prebuilt database included with comma

fixes #6 