### PR TITLE
Adding nix-index to the devShell.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
           };
 
           devShells.default = with pkgs; mkShell {
-            nativeBuildInputs = [ cargo rustc rustfmt rustPackages.clippy fzy ];
+            nativeBuildInputs = [ cargo nix-index rustc rustfmt rustPackages.clippy fzy ];
             RUST_SRC_PATH = rustPlatform.rustLibSrc;
           };
         })


### PR DESCRIPTION
This adds nix-index to the devShell environment, since it is a required dependency of comma.