### PR TITLE
Add `--update` flag with warning messages.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "3.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +75,38 @@ name = "comma"
 version = "1.2.3"
 dependencies = [
  "clap",
+ "xdg",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -163,6 +201,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +253,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +283,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"
@@ -236,3 +320,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "xdg"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6"
+dependencies = [
+ "dirs",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ license = "MIT"
 
 [dependencies]
 clap = { version = "3.1.11", features = ["derive", "cargo", "env"] }
+xdg = "2.4.0"

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,40 @@
+use std::{
+    os::unix::prelude::CommandExt,
+    process::Command,
+    time::{Duration, SystemTime},
+};
+
+/// Update the local nix-index database.
+pub fn update_database() {
+    println!("Updating nix-index database, takes around 5 minutes.");
+    Command::new("nix-index").exec();
+}
+
+/// Prints warnings if the nix-index database is non-existent or out of date.
+pub fn check_database() {
+    let base = xdg::BaseDirectories::with_prefix("nix-index").unwrap();
+    let cache_dir = base.get_cache_home();
+    let database_file = cache_dir.join("files");
+    if !database_file.exists() {
+        println!("Warning: Nix-index database does not exist, try updating with `--update`.");
+    } else if is_database_old(database_file) {
+        println!(
+            "Warning: Nix-index database is older than 30 days, try updating with `--update`."
+        );
+    }
+}
+
+/// Test whether the database is more than 30 days old
+fn is_database_old(database_file: std::path::PathBuf) -> bool {
+    let modified = match database_file.metadata() {
+        Ok(metadata) => metadata.modified().unwrap_or_else(|_| SystemTime::now()),
+        Err(_) => return false,
+    };
+    let time_since_modified = SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or(Duration::new(0, 0));
+    if time_since_modified > Duration::from_secs(30 * 24 * 60 * 60) {
+        return true;
+    }
+    false
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,13 +58,17 @@ fn run_command(use_channel: bool, choice: &str, command: &str, trail: &[String])
 fn main() -> ExitCode {
     let args = Opt::parse();
 
-    let command = &args.cmd[0];
-    let trail = &args.cmd[1..];
-
     if args.update {
-        println!("Updating nix-index database, takes around 5 minutes.");
         index::update_database();
     }
+
+    // The command may not be given if `--update` was specified.
+    if args.cmd.is_empty() {
+        return ExitCode::SUCCESS;
+    }
+
+    let command = &args.cmd[0];
+    let trail = &args.cmd[1..];
 
     index::check_database();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::{
 
 use clap::crate_version;
 use clap::Parser;
+use std::time::{Duration, SystemTime};
 
 fn pick(picker: &str, derivations: &[&str]) -> Option<String> {
     let mut picker_process = Command::new(&picker)
@@ -54,11 +55,47 @@ fn run_command(use_channel: bool, choice: &str, command: &str, trail: &[String])
     run_cmd.exec();
 }
 
+/// Test whether the database is more than 30 days old
+fn is_database_old(database_file: std::path::PathBuf) -> bool {
+    let modified = match database_file.metadata() {
+        Ok(metadata) => metadata.modified().unwrap_or_else(|_| SystemTime::now()),
+        Err(_) => return false,
+    };
+    let time_since_modified = SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or(Duration::new(0, 0));
+    if time_since_modified > Duration::from_secs(30 * 24 * 60 * 60) {
+        return true;
+    }
+    false
+}
+
+/// Prints warnings if the nix-index database is non-existent or out of date.
+fn check_database() {
+    let base = xdg::BaseDirectories::with_prefix("nix-index").unwrap();
+    let cache_dir = base.get_cache_home();
+    let database_file = cache_dir.join("files");
+    if !database_file.exists() {
+        println!("Warning: Nix-index database does not exist, try updating with `--update`.");
+    } else if is_database_old(database_file) {
+        println!(
+            "Warning: Nix-index database is older than 30 days, try updating with `--update`."
+        );
+    }
+}
+
 fn main() -> ExitCode {
     let args = Opt::parse();
 
     let command = &args.cmd[0];
     let trail = &args.cmd[1..];
+
+    if args.update {
+        println!("Updating nix-index database, takes around 5 minutes.");
+        Command::new("nix-index").exec();
+    }
+
+    check_database();
 
     let attrs = Command::new("nix-locate")
         .args(["--top-level", "--minimal", "--at-root", "--whole-name"])
@@ -68,7 +105,7 @@ fn main() -> ExitCode {
         .stdout;
 
     if attrs.is_empty() {
-        eprintln!("no match");
+        eprintln!("No executable `{}` found in nix-index database.", command);
         return ExitCode::FAILURE;
     }
 
@@ -115,7 +152,11 @@ struct Opt {
     #[clap(long, env = "COMMA_PICKER", default_value = "fzy")]
     picker: String,
 
+    /// Update nix-index database
+    #[clap(short, long)]
+    update: bool,
+
     /// Command to run
-    #[clap(required = true, name = "cmd")]
+    #[clap(required_unless_present = "update", name = "cmd")]
     cmd: Vec<String>,
 }


### PR DESCRIPTION
This change adds a new flag, `--update`, that will invoke `nix-index` to update the database.

Along with this change I've added better warning and error messages when dealing with a missing database. The user will now be warned, and told the appropriate remedy, if the database is missing or older than 30 days.

Unfortunately I did need to add another dependency to handle `xdg` settings correctly. I don't think it added too much size to the binary, but we should probably pay attention to that since this is now a 1MB binary instead of a <100 line bash script.

This was prompted by the UX issues seen in #21, and #23, which were created in #18