### PR TITLE
Allow to provide an `--inputs-from` argument when using flakes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ result
 # Added by cargo
 
 /target
+
+.direnv/


### PR DESCRIPTION
This allows pinning the nixpkgs to use when there exist a flake for the current system
(for example when using home-manager).

I realized it would be useful to me to reuse my home-manager config's nixpkgs instead of downloading a new one anytime the cache expires.

My rust is not in top shape, so I'm definitely open to comments on the style of the code (or in fixes, if you have some in mind).