### PR TITLE
Update Cargo version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "comma"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "clap",
  "xdg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "comma"
 description = "runs programs without installing them"
-version = "1.2.3"
+version = "1.3.0"
 edition = "2021"
 authors = ["Artturin <Artturin@artturin.com>"]
 license = "MIT"


### PR DESCRIPTION
This PR updates the version in Cargo.toml to 1.3.0, which will also ensure `, --version` gives the correct output