### PR TITLE
only warn about non-existent database if nix-locate fails

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -1,5 +1,6 @@
 use std::{
     os::unix::prelude::CommandExt,
+    path::PathBuf,
     process::Command,
     time::{Duration, SystemTime},
 };
@@ -10,18 +11,29 @@ pub fn update_database() {
     Command::new("nix-index").exec();
 }
 
-/// Prints warnings if the nix-index database is non-existent or out of date.
-pub fn check_database() {
-    let base = xdg::BaseDirectories::with_prefix("nix-index").unwrap();
-    let cache_dir = base.get_cache_home();
-    let database_file = cache_dir.join("files");
+/// Prints a warning if the nix-index database is non-existent
+pub fn check_database_exists() {
+    let database_file = get_database_file();
     if !database_file.exists() {
         println!("Warning: Nix-index database does not exist, try updating with `comma --update`.");
-    } else if is_database_old(database_file) {
+    }
+}
+
+/// Prints a warning if the nix-index database is out of date.
+pub fn check_database_updated() {
+    let database_file = get_database_file();
+    if is_database_old(database_file) {
         println!(
             "Warning: Nix-index database is older than 30 days, try updating with `comma --update`."
         );
     }
+}
+
+/// Get the location of the nix-index database file
+fn get_database_file() -> PathBuf {
+    let base = xdg::BaseDirectories::with_prefix("nix-index").unwrap();
+    let cache_dir = base.get_cache_home();
+    cache_dir.join("files")
 }
 
 /// Test whether the database is more than 30 days old

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ fn main() -> ExitCode {
     let command = &args.cmd[0];
     let trail = &args.cmd[1..];
 
-    index::check_database();
+    index::check_database_updated();
 
     let nix_locate_output = Command::new("nix-locate")
         .args(["--top-level", "--minimal", "--at-root", "--whole-name"])
@@ -79,6 +79,7 @@ fn main() -> ExitCode {
         .expect("failed to execute nix-locate");
 
     if !nix_locate_output.status.success() {
+        index::check_database_exists();
         match std::str::from_utf8(&nix_locate_output.stderr) {
             Ok(stderr) => eprintln!("nix-locate failed with: {}", stderr),
             Err(_) => eprint!("nix-locate failed"),


### PR DESCRIPTION
When using a non-standard database location for nix-index (e.g. via the NixOS module in the `github:Mic92/nix-index-database` flake), comma warns that the database is non-existent even though it does exist and nix-locate works fine

This changes the logic so that it only checks if the database exists when the `nix-locate` command fails

<details>
<summary>The warning I receive without this patch</summary>

```
[I] lily@bina ~> , node
Warning: Nix-index database does not exist, try updating with `--update`.
Welcome to Node.js v18.12.1.
```
</details>

<details>
<summary>The output with this patch when nix-locate fails to find database</summary>

```
[I] lily@bina ~> , node
Warning: Nix-index database does not exist, try updating with `comma --update`.
nix-locate failed with: error: reading from the database at '/home/lily/.cache/nix-index/files' failed.
This may be caused by a corrupt or missing database, try (re)running `nix-index` to generate the database.
If the error persists please file a bug report at https://github.com/bennofs/nix-index.
caused by: No such file or directory (os error 2)
```
</details>

<details>
<summary>The output with this patch when nix-locate succeeds</summary>

```
[I] lily@bina ~> , node
Welcome to Node.js v18.12.1.
```
</details>

<details>
<summary>The output with this patch for an unknown binary</summary>

```
[I] lily@bina ~> , nonexistentbin
No executable `nonexistentbin` found in nix-index database.
```
</details>