### PR TITLE
if index is a symlink consider its mtime instead of target's

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -38,7 +38,11 @@ fn get_database_file() -> PathBuf {
 
 /// Test whether the database is more than 30 days old
 fn is_database_old(database_file: std::path::PathBuf) -> bool {
-    let metadata = match database_file.metadata() {
+    let metadata = match if database_file.is_symlink() {
+        database_file.symlink_metadata()
+    } else {
+        database_file.metadata()
+    } {
         Ok(metadata) => metadata,
         Err(_) => return false,
     };


### PR DESCRIPTION
When `nix-index`'s database is managed via Mic92/nix-index-database I get the following warning: 

```
$ , cowsay hi
Warning: Nix-index database is older than 30 days, try updating with `--update`.
```

This happens because a symlink is place in `~/.cache/nix-index/file` pointing to the nix store and, with the current code, the check for old database looks at the target file of that symlink, which has no meaningful mtime.

This code changes the behavior to look at the symlink's mtime instead.