### PR TITLE
Add `--cache-level` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,42 @@ run it from whatever location it happens to occupy in `nixpkgs` without really t
 , cowsay neato
 ```
 
+### Cache
+
+Comma supports caching both the choices (i.e., once you select a derivation for
+a command, it will always return the same derivation) and paths (i.e., once the
+path is evaluated by Nix, we will always return the same path until it is GC'd).
+You can control those options by using `--cache-level` flag or `COMMA_CACHING`
+environment variable:
+
+- `0`: completely disables caching
+- `1`: only cache choices
+- `2` (default): also caches paths
+
+Cache for path is the default since it makes subsequent usage of a command much
+faster:
+
+```
+$ hyperfine "./result/bin/comma --cache-level=1 ls" "./result/bin/comma --cache-level=2 ls"
+Benchmark 1: ./result/bin/comma --cache-level=1 ls
+  Time (mean ± σ):      1.050 s ±  0.021 s    [User: 0.540 s, System: 0.210 s]
+  Range (min … max):    1.009 s …  1.075 s    10 runs
+
+Benchmark 2: ./result/bin/comma --cache-level=2 ls
+  Time (mean ± σ):       6.6 ms ±   1.0 ms    [User: 3.0 ms, System: 3.5 ms]
+  Range (min … max):     5.8 ms …  11.3 ms    297 runs
+
+  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
+
+Summary
+  ./result/bin/comma --cache-level=2 ls ran
+  159.25 ± 23.44 times faster than ./result/bin/comma --cache-level=1 ls
+```
+
+However, it also means you may not run the most up-to-date version of a
+command, specially if you don't run Nix's garbage collector often. If this is
+an issue for you, set `COMMA_CACHING=1`.
+
 ## Prebuilt index
 
 https://github.com/Mic92/nix-index-database

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -20,9 +20,9 @@ pub struct Cache {
 
 impl Cache {
     pub fn new() -> Result<Self, Box<dyn Error>> {
-        debug!("creating new cache instance");
-
         let path = xdg::BaseDirectories::new()?.place_state_file("comma/choices")?;
+
+        debug!("creating new cache instance for path: {}", path.display());
 
         Ok(Self {
             data: if path.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ mod shell;
 
 use std::{
     env,
-    error::Error,
     io::Write,
     os::unix::prelude::CommandExt,
     path::Path,
@@ -155,7 +154,7 @@ fn get_command_path(use_channel: bool, choice: &str, command: &str, nixpkgs_flak
 }
 
 fn get_command_path_from_cache(
-    cache: &mut Result<Cache, Box<dyn Error>>,
+    cache: &mut Option<Cache>,
     entry: &CacheEntry,
     use_channel: bool,
     command: &str,
@@ -165,12 +164,12 @@ fn get_command_path_from_cache(
         // If we have the path in the cache and it is not garbage collected
         // (so the path still exists), it should be safe to use it directly
         Some(path) if Path::new(&path).exists() => {
-            debug!("found path in cache for command '{command}': {path}");
+            debug!("found path from cache for command '{command}': {path}");
             path.to_owned()
         }
         // Otherwise, we need to find the command path
         _ => match cache {
-            Ok(ref mut cache) => {
+            Some(ref mut cache) => {
                 let path = get_command_path(use_channel, &entry.derivation, command, nixpkgs_flake);
                 debug!("found path from nix for command '{command}': {path}");
 
@@ -183,7 +182,7 @@ fn get_command_path_from_cache(
                 path
             }
 
-            Err(_) => {
+            None => {
                 let path = get_command_path(use_channel, &entry.derivation, command, nixpkgs_flake);
                 debug!("found path from nix for command '{command}': {path}");
 
@@ -194,7 +193,7 @@ fn get_command_path_from_cache(
 }
 
 fn run_command_from_cache(
-    cache: &mut Result<Cache, Box<dyn Error>>,
+    cache: &mut Option<Cache>,
     entry: &CacheEntry,
     use_channel: bool,
     command: &str,
@@ -218,13 +217,20 @@ fn main() -> ExitCode {
 
     let args = Opt::parse();
 
-    let mut cache = Cache::new();
-    if let Err(ref e) = cache {
-        eprintln!("failed to initialize cache, disabling related functionality: {e}");
-    }
+    let mut cache = if args.cache_level == 0 {
+        None
+    } else {
+        match Cache::new() {
+            Err(e) => {
+                eprintln!("failed to initialize cache, disabling related functionality: {e}");
+                None
+            }
+            Ok(x) => Some(x),
+        }
+    };
 
     if args.empty_cache {
-        if let Ok(ref mut cache) = cache {
+        if let Some(ref mut cache) = cache {
             cache.empty();
         }
     }
@@ -241,7 +247,7 @@ fn main() -> ExitCode {
     let trail = &args.cmd[1..];
 
     if args.delete_entry {
-        if let Ok(ref mut cache) = cache {
+        if let Some(ref mut cache) = cache {
             cache.delete(command);
         }
     }
@@ -265,7 +271,7 @@ fn main() -> ExitCode {
     }
 
     let entry = match cache {
-        Ok(ref mut cache) => cache.query(command).or_else(|| {
+        Some(ref mut cache) => cache.query(command).or_else(|| {
             index_database_pick(command, &args.picker).map(|derivation| {
                 let entry = CacheEntry {
                     derivation,
@@ -275,14 +281,21 @@ fn main() -> ExitCode {
                 entry
             })
         }),
-        Err(_) => index_database_pick(command, &args.picker).map(|derivation| CacheEntry {
+        None => index_database_pick(command, &args.picker).map(|derivation| CacheEntry {
             derivation,
             path: None,
         }),
     };
 
     let entry = match entry {
-        Some(d) => d,
+        Some(d) if args.cache_level >= 2 => d,
+        Some(d) => {
+            debug!("cache_level={}, ignoring path from cache", args.cache_level);
+            CacheEntry {
+                derivation: d.derivation.clone(),
+                path: None,
+            }
+        }
         None => return ExitCode::FAILURE,
     };
 
@@ -367,6 +380,11 @@ struct Opt {
     /// Print the absolute path to the executable in the nix store
     #[clap(short = 'x', long = "print-path")]
     print_path: bool,
+
+    /// Configure the cache level. 0 disables the cache, 1 enables cache for
+    /// choices, 2 also caches path evaluations
+    #[clap(long = "cache-level", env = "COMMA_CACHING", default_value_t = 2)]
+    cache_level: u8,
 
     /// Empty the cache
     #[clap(short, long = "empty-cache")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,9 +347,11 @@ struct Opt {
     #[clap(short, long)]
     shell: bool,
 
+    /// Picker to use
     #[clap(short = 'P', long, env = "COMMA_PICKER", default_value = "fzy")]
     picker: String,
 
+    /// Nixpkgs flake to use
     #[clap(
         short = 'F',
         long,
@@ -370,8 +372,8 @@ struct Opt {
     #[clap(short, long = "empty-cache")]
     empty_cache: bool,
 
-    /// Overwrite the cache entry for the specified command. This is achieved by first deleting it
-    /// from the cache, then running comma as normal.
+    /// Overwrite the cache entry for the specified command. This is achieved
+    /// by first deleting it from the cache, then running comma as normal
     #[clap(short, long = "delete-entry")]
     delete_entry: bool,
 


### PR DESCRIPTION
This is `u8` flag that accepts the following options:
- `0`: completely disables caching
- `1`: only cache choices
- `2`: also caches paths

Setting the default to 2 to keep the current behavior.

Also add documentation for the new flag in `README.md`, and some other misc fixes.

Closes: #90 (alternative implementation).