### PR TITLE
feat: remove "top-level" argument of "nix-locate"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn index_database(command: &str) -> Option<Box<[String]>> {
     index::check_database_updated();
 
     let nix_locate_output = Command::new("nix-locate")
-        .args(["--top-level", "--minimal", "--at-root", "--whole-name"])
+        .args(["--minimal", "--at-root", "--whole-name"])
         .arg(format!("/bin/{command}"))
         .output()
         .expect("failed to execute nix-locate");


### PR DESCRIPTION
Since version `v0.1.9` the `top-level` argument is the default behavior (https://github.com/nix-community/nix-index/commit/5bf97091c2608bf0db3374611b87259318138171#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR19)

This version is in the `master` branch of `nixpkgs` since this commit (https://github.com/NixOS/nixpkgs/commit/983df430c5f3221782c0dad10d4df872f02d002b)