### PR TITLE
Replace wrapProgram with substituteInPlace so PATH isn't polluted

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,17 +41,16 @@
           naersk-lib.buildPackage {
             pname = "comma";
             src = self;
-            nativeBuildInputs = [ makeWrapper ];
             overrideMain = _: {
+              postPatch = ''
+                substituteInPlace ./src/main.rs \
+                  --replace-fail '"nix-locate"' '"${lib.getExe' nix-index-unwrapped "nix-locate"}"' \
+                  --replace-fail '"nix"' '"${lib.getExe nix}"' \
+                  --replace-fail '"nix-env"' '"${lib.getExe' nix "nix-env"}"' \
+                  --replace-fail '"fzy"' '"${lib.getExe fzy}"'
+              '';
+
               postInstall = ''
-                wrapProgram $out/bin/comma \
-                  --prefix PATH : ${
-                    lib.makeBinPath ([
-                      nix
-                      fzy
-                      nix-index-unwrapped
-                    ])
-                  }
                 ln -s $out/bin/comma $out/bin/,
 
                 mkdir -p $out/etc/profile.d


### PR DESCRIPTION
Previously, when a command was executed with `, blah`, it would inherit the $PATH var from comma. This meant that there was some slight pollution, primarily since it would be the `nix`, `fzy`, and `nix-index` bin paths on PATH. Specifically they would be prefixed, so they would override any other entries. This could lead to confusing behavior if comma is built from a flake without overriding the nixpkgs input.

This changes it so that the paths are directly embedded in the binary, so no PATH pollution occurs.